### PR TITLE
Added skaffold support back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ run: ## Run the service
 .PHONY: cluster
 cluster: ## Create a K3D Kubernetes cluster with load balancer and registry
 	$(info Creating Kubernetes cluster with a registry and 1 worker node...)
-	k3d registry create registry.local --port 32000
-	k3d cluster create devops --agents 1 --registry-use k3d-registry.local:32000 --port '8080:80@loadbalancer'
+	k3d registry create registry.local --port 5000
+	k3d cluster create devops --agents 1 --registry-use k3d-registry.local:5000 --port '8080:80@loadbalancer'
 
 .PHONY: cluster-rm
 cluster-rm: ## Remove a K3D Kubernetes cluster

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -22,7 +22,8 @@ spec:
       restartPolicy: Always
       containers:
       - name: hitcounter
-        image: k3d-registry.local:32000/hitcounter:1.0
+        # image: k3d-registry.local:5000/hitcounter:1.0
+        image: hitcounter
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/skaffold.env
+++ b/skaffold.env
@@ -1,0 +1,1 @@
+SKAFFOLD_DEFAULT_REPO=k3d-registry.local:5000

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,9 +4,12 @@ metadata:
   name: hitcounter
 build:
   artifacts:
-    - image: registry.local:32000/hitcounter
+    - image: hitcounter
       docker:
         dockerfile: Dockerfile
+      # sync:
+      #   infer:
+      #   - 'service/**/*.py'
 test:
   - context: .
     image: hitcounter


### PR DESCRIPTION
Made file following changes:

- Changed the registry port from `32000` back to `5000` when creating the K3D cluster
- Added `skaffold.env` file to point `SKAFFOLD_DEFAULT_REPO` to the local `k3d-registry.local:5000` registry
- Removed registry prefixes from `skaffold.yaml` and `deployment.yaml` to let Skaffold manage them